### PR TITLE
Fix to FontWeight providing empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ export default class SwitchSelector extends Component {
           <Text
             style={{
               fontSize,
-              fontWeight: bold ? 'bold' : '',
+              fontWeight: bold ? 'bold' : 'normal',
               textAlign: 'center',
               color: this.state.selected == index ? selectedColor : textColor,
               backgroundColor: 'transparent'


### PR DESCRIPTION
Fix for:
```
Warning: Failed prop type: Invalid prop `fontWeight` of value `` supplied to `Text`, expected one of ["normal","bold","100","200","300","400","500","600","700","800","900"].
Bad object: {
  "fontSize": 14,
  "fontWeight": "",
  "textAlign": "center",
  "color": "#FFFFFF",
  "backgroundColor": "transparent"
}
```