### PR TITLE
Add check for valid index / value prop documentation / types

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ const options = [
 | options[].imageIcon   | string                  | null        | false    | Source from a image icon form each item. Has the same color then label in render |
 | options[].activeColor | string                  | null        | false    | Color from each item when is selected                                            |
 | initial               | number                  | 0           | true     | Item selected in initial render                                                  |
+| value                 | number                  | undefined   | true     | The switch value (will call onPress)                                             |
 | onPress               | function                | console.log | true     | Callback function called after change value.                                     |
 | fontSize              | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
 | selectedColor         | string                  | '#fff'      | false    | Color text of the item selected                                                  |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const options = [
 | options[].imageIcon   | string                  | null        | false    | Source from a image icon form each item. Has the same color then label in render |
 | options[].activeColor | string                  | null        | false    | Color from each item when is selected                                            |
 | initial               | number                  | 0           | true     | Item selected in initial render                                                  |
-| value                 | number                  | undefined   | true     | The switch value (will call onPress)                                             |
+| value                 | number                  | undefined   | false    | The switch value (will call onPress)                                             |
 | onPress               | function                | console.log | true     | Callback function called after change value.                                     |
 | fontSize              | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
 | selectedColor         | string                  | '#fff'      | false    | Color text of the item selected                                                  |

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,11 @@
 declare module "react-native-switch-selector" {
   import { Component } from "react";
-  import { ImageStyle, TextStyle, ViewStyle } from "react-native";
+  import {
+    ImageStyle,
+    RegisteredStyle,
+    TextStyle,
+    ViewStyle
+  } from "react-native";
 
   export interface ISwitchSelectorOption {
     label: string;
@@ -13,7 +18,7 @@ declare module "react-native-switch-selector" {
   export interface ISwitchSelectorProps {
     options: ISwitchSelectorOption[];
     initial: number;
-    value: number;
+    value?: number;
     onPress(value: string | number | ISwitchSelectorOption): void;
     fontSize?: number;
     selectedColor?: string;
@@ -30,7 +35,7 @@ declare module "react-native-switch-selector" {
     textStyle?: TextStyle;
     selectedTextStyle?: TextStyle;
     imageStyle?: ImageStyle;
-    style?: ViewStyle;
+    style?: ViewStyle | RegisteredStyle<ViewStyle>;
     returnObject?: boolean;
     disabled?: boolean;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,9 +32,9 @@ declare module "react-native-switch-selector" {
     valuePadding?: number;
     height?: number;
     bold?: boolean;
-    textStyle?: TextStyle;
-    selectedTextStyle?: TextStyle;
-    imageStyle?: ImageStyle;
+    textStyle?: TextStyle | RegisteredStyle<TextStyle>;
+    selectedTextStyle?: TextStyle | RegisteredStyle<TextStyle>;
+    imageStyle?: ImageStyle | RegisteredStyle<ImageStyle>;
     style?: ViewStyle | RegisteredStyle<ViewStyle>;
     returnObject?: boolean;
     disabled?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module "react-native-switch-selector" {
   export interface ISwitchSelectorProps {
     options: ISwitchSelectorOption[];
     initial: number;
+    value: number;
     onPress(value: string | number | ISwitchSelectorOption): void;
     fontSize?: number;
     selectedColor?: string;

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ export default class SwitchSelector extends Component {
 
   toggleItem = index => {
     const { options, returnObject, onPress } = this.props;
-    if (options.length <= 1) return;
+    if (options.length <= 1 || index === null || isNaN(index)) return;
     this.animate(
       I18nManager.isRTL ? -(index / options.length) : index / options.length,
       I18nManager.isRTL


### PR DESCRIPTION
I added a check for invalid index values in `toggleItem`.
Sometimes when re-rendering the switch, I was getting an error because it would try to evaluate using invalid indexes that were being passed to `toggleItem`.
