### PR TITLE
Add optional prop to prevent onPress being called on value change

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,35 +67,36 @@ const options = [
 
 ### Props
 
-| Prop                  | Type                    | Default     | Required | Note                                                                             |
-| --------------------- | ----------------------- | ----------- | -------- | -------------------------------------------------------------------------------- |
-| options               | array                   | null        | true     | Items array to render. Each item has a label and a value and optionals icons     |
-| options[].label       | string                  | null        | true     | Label from each item                                                             |
-| options[].value       | string                  | null        | true     | Value from each item                                                             |
-| options[].customIcon  | Jsx element ou Function | null        | false    | Optional custom icon from each item                                              |
-| options[].imageIcon   | string                  | null        | false    | Source from a image icon form each item. Has the same color then label in render |
-| options[].activeColor | string                  | null        | false    | Color from each item when is selected                                            |
-| initial               | number                  | 0           | true     | Item selected in initial render                                                  |
-| value                 | number                  | undefined   | false    | The switch value (will call onPress)                                             |
-| onPress               | function                | console.log | true     | Callback function called after change value.                                     |
-| fontSize              | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
-| selectedColor         | string                  | '#fff'      | false    | Color text of the item selected                                                  |
-| buttonColor           | string                  | '#BCD635'   | false    | Color bg of the item selected                                                    |
-| textColor             | string                  | '#000'      | false    | Color text of the not selecteds items                                            |
-| backgroundColor       | string                  | '#ffffff'   | false    | Color bg of the component                                                        |
-| borderColor           | string                  | '#c9c9c9'   | false    | Border Color of the component                                                    |
-| borderRadius          | number                  | 50          | false    | Border Radius of the component                                                   |
-| hasPadding            | bool                    | false       | false    | Indicate if item has padding                                                     |
-| animationDuration     | number                  | 250         | false    | Duration of the animation                                                        |
-| valuePadding          | number                  | 1           | false    | Size of padding                                                                  |
-| height                | number                  | 40          | false    | Height of component                                                              |
-| bold                  | bool                    | false       | false    | Indicate if text has fontWeight bold                                             |
-| textStyle             | object                  | {}          | false    | Text style                                                                       |
-| selectedTextStyle     | object                  | {}          | false    | Selected text style                                                              |
-| imageStyle            | object                  | {}          | false    | Image style                                                                      |
-| style                 | object                  | {}          | false    | Container style                                                                  |
-| returnObject          | bool                    | false       | false    | Indicate if onPress function return an option instead of option.value            |
-| disabled              | bool                    | false       | false    | Disables the switch                                                              |
+| Prop                      | Type                    | Default     | Required | Note                                                                             |
+| ------------------------- | ----------------------- | ----------- | -------- | -------------------------------------------------------------------------------- |
+| options                   | array                   | null        | true     | Items array to render. Each item has a label and a value and optionals icons     |
+| options[].label           | string                  | null        | true     | Label from each item                                                             |
+| options[].value           | string                  | null        | true     | Value from each item                                                             |
+| options[].customIcon      | Jsx element ou Function | null        | false    | Optional custom icon from each item                                              |
+| options[].imageIcon       | string                  | null        | false    | Source from a image icon form each item. Has the same color then label in render |
+| options[].activeColor     | string                  | null        | false    | Color from each item when is selected                                            |
+| initial                   | number                  | 0           | true     | Item selected in initial render                                                  |
+| value                     | number                  | undefined   | false    | The switch value (will call onPress)                                             |
+| onPress                   | function                | console.log | true     | Callback function called after change value.                                     |
+| disableValueChangeOnPress | bool                    | false       | false    | Disables the onPress call when the value is manually changed                     |
+| fontSize                  | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
+| selectedColor             | string                  | '#fff'      | false    | Color text of the item selected                                                  |
+| buttonColor               | string                  | '#BCD635'   | false    | Color bg of the item selected                                                    |
+| textColor                 | string                  | '#000'      | false    | Color text of the not selecteds items                                            |
+| backgroundColor           | string                  | '#ffffff'   | false    | Color bg of the component                                                        |
+| borderColor               | string                  | '#c9c9c9'   | false    | Border Color of the component                                                    |
+| borderRadius              | number                  | 50          | false    | Border Radius of the component                                                   |
+| hasPadding                | bool                    | false       | false    | Indicate if item has padding                                                     |
+| animationDuration         | number                  | 250         | false    | Duration of the animation                                                        |
+| valuePadding              | number                  | 1           | false    | Size of padding                                                                  |
+| height                    | number                  | 40          | false    | Height of component                                                              |
+| bold                      | bool                    | false       | false    | Indicate if text has fontWeight bold                                             |
+| textStyle                 | object                  | {}          | false    | Text style                                                                       |
+| selectedTextStyle         | object                  | {}          | false    | Selected text style                                                              |
+| imageStyle                | object                  | {}          | false    | Image style                                                                      |
+| style                     | object                  | {}          | false    | Container style                                                                  |
+| returnObject              | bool                    | false       | false    | Indicate if onPress function return an option instead of option.value            |
+| disabled                  | bool                    | false       | false    | Disables the switch                                                              |
 
 ### Authors
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ declare module "react-native-switch-selector" {
     style?: ViewStyle | RegisteredStyle<ViewStyle>;
     returnObject?: boolean;
     disabled?: boolean;
+    disableValueChangeOnPress?: boolean;
   }
 
   class SwitchSelector extends Component<ISwitchSelectorProps> {}

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export default class SwitchSelector extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
-      this.toggleItem(nextProps.value, this.props.disableValueChangeOnPress && false);
+      this.toggleItem(nextProps.value, !this.props.disableValueChangeOnPress);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export default class SwitchSelector extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
-      this.toggleItem(nextProps.value);
+      this.toggleItem(nextProps.value, this.props.disableValueChangeOnPress && false);
     }
   }
 
@@ -265,5 +265,6 @@ SwitchSelector.defaultProps = {
   buttonColor: "#BCD635",
   returnObject: false,
   animationDuration: 100,
-  disabled: false
+  disabled: false,
+  disableValueChangeOnPress: false
 };


### PR DESCRIPTION
Added an optional prop to prevent `onPress` from being called when `value` is changed programmatically.

The `toggleItem` method already had the default argument `callOnPress = true`. Nothing was utilizing this `callOnPress`, so I just added a check to use it within `componentWillReceiveProps`. 