### PR TITLE
Add button margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const options = [
 | disableValueChangeOnPress  | bool                    | false       | false    | Disables the onPress call when the value is manually changed                     |
 | fontSize                   | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
 | selectedColor              | string                  | '#fff'      | false    | Color text of the item selected                                                  |
+| buttonMargin               | string                  | null        | false    | Margin of the item selected to the component                                     |
 | buttonColor                | string                  | '#BCD635'   | false    | Color bg of the item selected                                                    |
 | textColor                  | string                  | '#000'      | false    | Color text of the not selecteds items                                            |
 | backgroundColor            | string                  | '#ffffff'   | false    | Color bg of the component                                                        |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const options = [
 | disableValueChangeOnPress  | bool                    | false       | false    | Disables the onPress call when the value is manually changed                     |
 | fontSize                   | number                  | null        | false    | Font size from labels. If null default fontSize of the app is used.              |
 | selectedColor              | string                  | '#fff'      | false    | Color text of the item selected                                                  |
-| buttonMargin               | string                  | null        | false    | Margin of the item selected to the component                                     |
+| buttonMargin               | number                  | 0           | false    | Margin of the item selected to component                                         |
 | buttonColor                | string                  | '#BCD635'   | false    | Color bg of the item selected                                                    |
 | textColor                  | string                  | '#000'      | false    | Color text of the not selecteds items                                            |
 | backgroundColor            | string                  | '#ffffff'   | false    | Color bg of the component                                                        |

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module "react-native-switch-selector" {
     onPress(value: string | number | ISwitchSelectorOption): void;
     fontSize?: number;
     selectedColor?: string;
+    buttonMargin?: number;
     buttonColor?: string;
     textColor?: string;
     backgroundColor?: string;

--- a/index.js
+++ b/index.js
@@ -139,7 +139,8 @@ export default class SwitchSelector extends Component {
       valuePadding,
       height,
       bold,
-      disabled
+      disabled,
+      buttonMargin
     } = this.props;
 
     const options = this.props.options.map((element, index) => {
@@ -194,7 +195,7 @@ export default class SwitchSelector extends Component {
             style={{
               borderRadius: borderRadius,
               backgroundColor: backgroundColor,
-              height
+              height: buttonMargin ? (height + (buttonMargin * 2)) : height
             }}
             onLayout={event => {
               const { width } = event.nativeEvent.layout;
@@ -220,7 +221,7 @@ export default class SwitchSelector extends Component {
                       backgroundColor: this.getBgColor(),
                       width:
                         this.state.sliderWidth / this.props.options.length -
-                        (hasPadding ? valuePadding : 0),
+                        ((hasPadding ? valuePadding : 0) + (buttonMargin ? buttonMargin * 2 : 0)),
                       transform: [
                         {
                           translateX: this.animatedValue.interpolate({
@@ -234,7 +235,7 @@ export default class SwitchSelector extends Component {
                         }
                       ],
                       borderRadius: borderRadius,
-                      marginTop: hasPadding ? valuePadding : 0
+                      margin: buttonMargin ? buttonMargin : 0
                     },
                     styles.animated
                   ]}

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ export default class SwitchSelector extends Component {
             style={{
               borderRadius: borderRadius,
               backgroundColor: backgroundColor,
-              height: buttonMargin ? (height + (buttonMargin * 2)) : height
+              height: height + (buttonMargin * 2)
             }}
             onLayout={event => {
               const { width } = event.nativeEvent.layout;
@@ -221,7 +221,7 @@ export default class SwitchSelector extends Component {
                       backgroundColor: this.getBgColor(),
                       width:
                         this.state.sliderWidth / this.props.options.length -
-                        ((hasPadding ? valuePadding : 0) + (buttonMargin ? buttonMargin * 2 : 0)),
+                        ((hasPadding ? valuePadding : 0) + (buttonMargin * 2)),
                       transform: [
                         {
                           translateX: this.animatedValue.interpolate({
@@ -235,7 +235,7 @@ export default class SwitchSelector extends Component {
                         }
                       ],
                       borderRadius: borderRadius,
-                      margin: buttonMargin ? buttonMargin : 0
+                      margin: buttonMargin
                     },
                     styles.animated
                   ]}
@@ -267,6 +267,7 @@ SwitchSelector.defaultProps = {
   valuePadding: 1,
   height: 40,
   bold: false,
+  buttonMargin: 0,
   buttonColor: "#BCD635",
   returnObject: false,
   animationDuration: 100,


### PR DESCRIPTION
Add props `buttonMargin`, to add custom margin arround button

Fix this issues: https://github.com/App2Sales/react-native-switch-selector/issues/43

<img width="416" alt="Screen Shot 2019-10-02 at 19 06 36" src="https://user-images.githubusercontent.com/6845983/66043392-353bde00-e549-11e9-8103-682c6ab1e508.png">
