### PR TITLE
fix: set the current index instead the previous index

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ export default class SwitchSelector extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
-      this.toggleItem(prevProps.value, !this.props.disableValueChangeOnPress);
+      this.toggleItem(this.props.value, !this.props.disableValueChangeOnPress);
     }
   }
 


### PR DESCRIPTION
https://github.com/App2Sales/react-native-switch-selector/issues/54#issue-516924958