### PR TITLE
add `borderWidth` to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare module "react-native-switch-selector" {
     backgroundColor?: string;
     borderColor?: string;
     borderRadius?: number;
+    borderWidth?: number;
     hasPadding?: boolean;
     animationDuration?: number;
     valuePadding?: number;


### PR DESCRIPTION
the prop is defined in the index.js file but it's not defined in the index.d.ts